### PR TITLE
Replace loop with cl-loop

### DIFF
--- a/yaml-imenu.el
+++ b/yaml-imenu.el
@@ -100,7 +100,7 @@
     (widen)
     (goto-char (point-min))
     (let ((currlinum 1))
-      (loop for (key . value) in alist
+      (cl-loop for (key . value) in alist
             collect (cons (symbol-name key)
                           (if (numberp value)
                               (let ((diff (- value currlinum)))


### PR DESCRIPTION
Fixes #1.

Tested on Emacs 27.1. [Autloads](https://github.com/emacs-mirror/emacs/blob/emacs-24.4/lisp/emacs-lisp/cl-macs.el#L774) at least back to the Emacs-24.4 that's required.