### PR TITLE
Fix #3: wrong usage of with-current-buffer

### DIFF
--- a/parse_yaml.rb
+++ b/parse_yaml.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require 'yaml'
 require 'json'
 
@@ -16,7 +18,7 @@ end
 def parse(node, current_path = nil)
   case node
   when Psych::Nodes::Scalar, Psych::Nodes::Alias
-    nil
+  { current_path => node.start_line + 1 } if current_path
   when Psych::Nodes::Mapping
     initial =
       if current_path

--- a/yaml-imenu.el
+++ b/yaml-imenu.el
@@ -29,7 +29,7 @@
 ;; URL: https://github.com/knu/yaml-imenu.el
 ;; Created: 25 Sep 2018
 ;; Version: 1.0.2
-;; Package-Requires: ((emacs "24.4") (yaml-mode "0"))
+;; Package-Requires: ((emacs "24.4") (yaml-mode "0") (cl-macs "0"))
 ;; Keywords: outlining, convenience, imenu
 
 ;;; Commentary:
@@ -83,16 +83,17 @@
          (json-array-type 'list))
      (json-read-from-string
       (with-output-to-string
-        (shell-command-on-region
-         (point-min)
-         (point-max)
-         (mapconcat
-          'shell-quote-argument
-          (list
-           "ruby"
-           (expand-file-name "parse_yaml.rb" (yaml-imenu-source-directory)))
-          " ")
-         standard-output))))))
+        (cl-letf (((symbol-function 'display-message-or-buffer) #'ignore))
+          (shell-command-on-region
+           (point-min)
+           (point-max)
+           (mapconcat
+            'shell-quote-argument
+            (list
+             "ruby"
+             (expand-file-name "parse_yaml.rb" (yaml-imenu-source-directory)))
+            " ")
+           standard-output)))))))
 
 (defun yaml-imenu--json-to-index (alist)
   "Reformat the JSON representation ALIST into an imenu index."

--- a/yaml-imenu.el
+++ b/yaml-imenu.el
@@ -83,18 +83,16 @@
          (json-array-type 'list))
      (json-read-from-string
       (with-output-to-string
-        (with-current-buffer
-            standard-output
-          (shell-command-on-region
-           (point-min)
-           (point-max)
-           (mapconcat
-            'shell-quote-argument
-            (list
-             "ruby"
-             (expand-file-name "parse_yaml.rb" (yaml-imenu-source-directory)))
-            " ")
-           t)))))))
+        (shell-command-on-region
+         (point-min)
+         (point-max)
+         (mapconcat
+          'shell-quote-argument
+          (list
+           "ruby"
+           (expand-file-name "parse_yaml.rb" (yaml-imenu-source-directory)))
+          " ")
+         standard-output))))))
 
 (defun yaml-imenu--json-to-index (alist)
   "Reformat the JSON representation ALIST into an imenu index."


### PR DESCRIPTION
`with-output-to-string` will temporarily change variable
`standard-output` with value `"#<buffer *string-output*>"`.

and the code

```elisp
  (with-current-buffer
      standard-output
    ...)
```

will change the current buffer into buffer `standard-output`,
that's the buffer `"#<buffer  *string-output*>"`,
and use functions like `point-min`, `point-max`, `shell-command-on-region` is pointless,
because the current buffer is an empty buffer.

Check https://stackoverflow.com/questions/3576192 for details.
