### PR TITLE
Fix capture of parse output inside yaml-imenu-create-index

### DIFF
--- a/yaml-imenu.el
+++ b/yaml-imenu.el
@@ -83,18 +83,16 @@
          (json-array-type 'list))
      (json-read-from-string
       (with-output-to-string
-        (with-current-buffer
-            standard-output
-          (shell-command-on-region
-           (point-min)
-           (point-max)
-           (mapconcat
-            'shell-quote-argument
-            (list
-             "ruby"
-             (expand-file-name "parse_yaml.rb" (yaml-imenu-source-directory)))
-            " ")
-           t)))))))
+        (shell-command-on-region
+         (point-min)
+         (point-max)
+         (mapconcat
+          'shell-quote-argument
+          (list
+           "ruby"
+           (expand-file-name "parse_yaml.rb" (yaml-imenu-source-directory)))
+          " ")
+         standard-output))))))
 
 (defun yaml-imenu--json-to-index (alist)
   "Reformat the JSON representation ALIST into an imenu index."


### PR DESCRIPTION
Remove the unnecessary `with-current-buffer` wrapper.