### PR TITLE
update cl-lib; convert to minor-mode and restore imenu-create-index-f…

### DIFF
--- a/parse_yaml.rb
+++ b/parse_yaml.rb
@@ -5,8 +5,8 @@ def main
   parsed =
     begin
       parse(YAML.parse(ARGF).children.first) || {}
-    rescue => e
-      STDERR.puts e.message
+    rescue StandardError => e
+      warn e.message
       {}
     end
 
@@ -25,7 +25,7 @@ def parse(node, current_path = nil)
         {}
       end
 
-    node.children.each_slice(2).reduce(initial) { |hash, (ykey, yvalue)|
+    node.children.each_slice(2).reduce(initial) do |hash, (ykey, yvalue)|
       key =
         case ykey
         when Psych::Nodes::Scalar
@@ -44,7 +44,7 @@ def parse(node, current_path = nil)
       else
         hash
       end
-    }
+    end
   when Psych::Nodes::Sequence
     initial =
       if current_path
@@ -53,13 +53,13 @@ def parse(node, current_path = nil)
         {}
       end
 
-    node.children.each_with_index.reduce(initial) { |hash, (yvalue, i)|
+    node.children.each_with_index.reduce(initial) do |hash, (yvalue, i)|
       if value = parse(yvalue, "#{current_path}[#{i}]")
         hash.merge(value)
       else
         hash
       end
-    }
+    end
   end
 end
 

--- a/yaml-imenu.el
+++ b/yaml-imenu.el
@@ -60,7 +60,7 @@
 
 ;;; Code:
 (eval-when-compile (require 'cl-lib))
-(require 'yaml-mode)
+(require 'yaml-mode nil t)
 (require 'json)
 
 (defvar yaml-imenu-parser
@@ -116,13 +116,12 @@
 (define-minor-mode yaml-imenu-mode
   "Enable `yaml-imenu' support."
   :lighter nil
-  (if yaml-imenu-mode
-      (progn
-        (setq imenu--index-alist nil)
-        (add-function :before-until (local 'imenu-create-index-function)
-                      #'yaml-imenu-create-index))
-    (remove-function (local 'imenu-create-index-function)
-                     #'yaml-imenu-create-index)))
+  (if (not yaml-imenu-mode)
+      (remove-function
+       (local 'imenu-create-index-function) #'yaml-imenu-create-index)
+    (setq imenu--index-alist nil)
+    (add-function :before-until (local 'imenu-create-index-function)
+                  #'yaml-imenu-create-index)))
 
 (provide 'yaml-imenu)
 ;;; yaml-imenu.el ends here


### PR DESCRIPTION
In case you're interested. This updates to cl-lib, lexical-binding, and 
determines ruby parser on load/compile.  The toggling functions are replaced
by a minor-mode that doesn't clobber previous `imenu-create-index-function`s.